### PR TITLE
Fixed plugins work with mirrored image

### DIFF
--- a/source/gui.py
+++ b/source/gui.py
@@ -146,7 +146,9 @@ class MainWindow(QMainWindow):
         if self.in_port == -1:
             return False
         self.virtual_camera.start_stream(self.in_port, self.out_port)
+        self.start_preview()
 
+    def start_preview(self):
         self.capture = cv2.VideoCapture(self.out_port)
         self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, self.video_size.width())
         self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, self.video_size.height())

--- a/source/main.py
+++ b/source/main.py
@@ -45,8 +45,10 @@ class VirtualCamera:
     def stream_step(self):
         try:
             _, frame = self.camera_input.read()
-            frame = frame[:, :, ::-1]
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            frame = cv2.flip(frame, 1)  # Mirror
             processed_frame = self._virtual_mapping(frame)
+            processed_frame = cv2.flip(processed_frame, 1)  # Mirror back
         except Exception as e:
             print(e)
         self.fake_camera.schedule_frame(processed_frame)

--- a/source/plugins/fps_plugin.py
+++ b/source/plugins/fps_plugin.py
@@ -39,9 +39,7 @@ class FPSPlugin(Plugin):
         font_scale = 0.6
         font_color = (255, 255, 255)
         line_type = 2
-        frame = cv2.flip(frame, 1)
         frame = cv2.putText(frame, self.fps, xy, font, font_scale, font_color, lineType=line_type)
-        frame = cv2.flip(frame, 1)
         return frame
 
     def save(self):


### PR DESCRIPTION
Solves issue #46. 
The camera feed is normally in-mirror, so the plugins were previously working (not intuitively) with the mirrored frame.